### PR TITLE
fix: use sample player with overrideNative for fmp4 608 captions post

### DIFF
--- a/source/_posts/Inband-Captions-Support-with-VHS.md
+++ b/source/_posts/Inband-Captions-Support-with-VHS.md
@@ -14,9 +14,9 @@ date: 2019-01-16 18:36:32
 ---
 
 
-With the release of [videojs-http-streaming](https://blog.videojs.com/introducing-video-js-http-streaming-vhs/) (VHS) v1.2.0 on July 16th 2018, Video.js has built-in support for CEA/CTA-608 captions carried in FMP4 segments. This means that closed captions are automatically parsed out and made available to Video.js players for MPEG-DASH content and HLS streams using FMP4 segments. Here's a [sample player](http://jsfiddle.net/wtyxu4sp) that shows the captions (English with the "CC" button is the track with CEA-608 captions).
+With the release of [videojs-http-streaming](https://blog.videojs.com/introducing-video-js-http-streaming-vhs/) (VHS) v1.2.0 on July 16th 2018, Video.js has built-in support for CEA/CTA-608 captions carried in FMP4 segments. This means that closed captions are automatically parsed out and made available to Video.js players for MPEG-DASH content and HLS streams using FMP4 segments. Here's a [sample player](https://jsfiddle.net/ugnkw65y/) that shows the captions (English with the "CC" button is the track with CEA-608 captions).
 
-{% iframe https://jsfiddle.net/wtyxu4sp/13/embedded/result,html/light 100% 550 %}
+{% iframe https://jsfiddle.net/ugnkw65y/1/embedded/result,html/light 100% 550 %}
 
 If you are curious about CEA-608 captions and the approach we used to parse them out of fmp4s, or a general overivew, you can watch my [talk from Demuxed 2018](https://www.twitch.tv/videos/326082416?collection=u1vmyYMIYBXvlQ).
 


### PR DESCRIPTION
Turns out the sample didn't play on Android so let's use VHS!